### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1](https://github.com/fasterthanlime/oval/compare/v1.0.0...v1.0.1) - 2024-01-30
+
+### Other
+- Add nix flake for consistent environment on Linux

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "oval"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bytes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oval"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Geoffroy Couprie <geo.couprie@gmail.com>", "Amos Wenger <amoswenger@gmail.com>"]
 description = "A stream abstraction designed for use with nom"
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `oval`: 1.0.0 -> 1.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.1](https://github.com/fasterthanlime/oval/compare/v1.0.0...v1.0.1) - 2024-01-30

### Other
- Add nix flake for consistent environment on Linux
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).