### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/fasterthanlime/oval/compare/v1.0.1...v2.0.0) - 2024-01-31
+
+### Added
+- [**breaking**] Bump bytes dependency, implement BufMut ([#4](https://github.com/fasterthanlime/oval/pull/4))
+
 ## [1.0.1](https://github.com/fasterthanlime/oval/compare/v1.0.0...v1.0.1) - 2024-01-30
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "oval"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "bytes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oval"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["Geoffroy Couprie <geo.couprie@gmail.com>", "Amos Wenger <amoswenger@gmail.com>"]
 description = "A stream abstraction designed for use with nom, winnow, etc."
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `oval`: 1.0.1 -> 2.0.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/fasterthanlime/oval/compare/v1.0.1...v2.0.0) - 2024-01-31

### Added
- [**breaking**] Bump bytes dependency, implement BufMut ([#4](https://github.com/fasterthanlime/oval/pull/4))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).